### PR TITLE
feat: add Sail from the JVM post, in Spanish and English

### DIFF
--- a/0006-sail-jvm-en.md
+++ b/0006-sail-jvm-en.md
@@ -19,9 +19,9 @@ Sail speaks **Spark Connect**. And Spark publishes a JVM client, `spark-connect-
 
 The problem is starting it. Sail is a Rust binary **shipped as a Python wheel**. From Python you `pip install pysail`, run `sail spark server`, and that is that. From the JVM there is nothing at all that brings a server up: no artifact on Maven, no class to call, nothing.
 
-That is what [`sail-testkit`](https://github.com/devel0pez-com/sail-testkit) is. It is the missing piece and nothing more than that: it starts the process, hands you the url, and kills it when the suite ends.
+That is what [`sail-testkit`](https://github.com/devel0pez-com/sail-testkit) is. It is the missing piece and nothing more than that: it starts the process, hands you the URL, and kills it when the suite ends.
 
-And as of yesterday it is **on Maven Central**:
+And it is **on Maven Central**:
 
 ```scala
 libraryDependencies += "com.devel0pez" %% "sail-testkit" % "0.1.0" % Test

--- a/0006-sail-jvm-en.md
+++ b/0006-sail-jvm-en.md
@@ -1,0 +1,436 @@
+---
+layout: default
+title: "Sail from the JVM: a test kit on Maven Central, and what I found on the way"
+date: 2026-08-30
+categories: Blog
+---
+
+# ⛵ Sail from the JVM: a test kit on Maven Central, and what I found on the way
+
+I have spent a few posts now talking about [Sail](https://github.com/lakehq/sail) from Python. The question left over was the obvious one: **can I take my Spark tests in Scala and point them at Sail?**
+
+The short answer is yes, and that far more of them run than I expected. The long answer is this post: a launcher published on Maven Central, a template with two engines, and a finding that has changed how I write Spark — and it is not about Sail, it is about Spark.
+
+---
+
+## 🕳️ The gap
+
+Sail speaks **Spark Connect**. And Spark publishes a JVM client, `spark-connect-client-jvm`, that speaks the same protocol. So on paper the pieces are all there: Scala client, Rust server, gRPC in between.
+
+The problem is starting it. Sail is a Rust binary **shipped as a Python wheel**. From Python you `pip install pysail`, run `sail spark server`, and that is that. From the JVM there is nothing at all that brings a server up: no artifact on Maven, no class to call, nothing.
+
+That is what [`sail-testkit`](https://github.com/devel0pez-com/sail-testkit) is. It is the missing piece and nothing more than that: it starts the process, hands you the url, and kills it when the suite ends.
+
+And as of yesterday it is **on Maven Central**:
+
+```scala
+libraryDependencies += "com.devel0pez" %% "sail-testkit" % "0.1.0" % Test
+```
+
+---
+
+## 📦 How you use it
+
+Mix `SailSuite` into a ScalaTest suite and you get a `spark` that talks to Sail:
+
+```scala
+import com.devel0pez.sail.testkit.SailSuite
+import org.scalatest.funsuite.AnyFunSuite
+
+class MyEtlSpec extends AnyFunSuite with SailSuite {
+  test("aggregates by key") {
+    val out = MyEtl.transform(spark.read.parquet("src/test/resources/input"))
+    assert(out.count() == 3)
+  }
+}
+```
+
+`sbt test` and that is it. One server per suite, started in `beforeAll` and stopped in `afterAll`. If you would rather own the session yourself, the launcher stands alone:
+
+```scala
+SailServer.withServer { server =>
+  val spark = SparkSession.builder().remote(server.url).getOrCreate()
+  ...
+}
+```
+
+There is one design decision I am happy with: **`SailSuite` configures nothing about the session**. Not ANSI mode, not a time zone, nothing that changes what a query means. Those are your project's decisions, and a test kit that quietly made them would be answering a question nobody asked it. There is a hook, and that is all:
+
+```scala
+override protected def configureSession(session: SparkSession): Unit =
+  session.conf.set("spark.sql.ansi.enabled", "true")
+```
+
+That hook, incidentally, did not come from thinking it through. It came from consuming the artifact from the Scala template via `publishLocal` and finding myself fighting my own library.
+
+### The details that cost an afternoon
+
+Three things about the launcher that look trivial and are not:
+
+**The pipe has to be drained.** Sail logs to stderr. If nobody reads that pipe it fills up and Sail blocks on its own logging. The symptom is a hang with no cause visible anywhere. Discarding the output would avoid that too, but then a server that dies takes the reason with it.
+
+**So it keeps the last 20 lines** and puts them in the failure. A server that dies on startup says why:
+
+```
+The Sail server exited while starting up (code 1). It printed:
+  error: failed to bind: Address already in use (os error 48)
+```
+
+**The reader thread is a daemon.** A test kit must never be the reason a JVM refuses to exit.
+
+---
+
+## 🧨 The requirements that are written down nowhere
+
+This is the section that would have saved me half the work.
+
+**`pyspark` has to be installed next to `pysail`.** Sail resolves *its* Spark version by asking that module, on its own side. Without it, `spark.version` answers:
+
+```
+invalid argument: failed to get PySpark version:
+ModuleNotFoundError: No module named 'pyspark'
+```
+
+**Java 17+ and the `--add-opens` flags.** Spark and Arrow reach into JDK internals by reflection, and that has been sealed off since Java 17. `spark-submit` passes those flags for you; sbt does not. Without them the first `collect()` dies with `sun.misc.Unsafe ... not available` — and it is a *run-time* failure, so a build that compiles cleanly still dies on its first row.
+
+```scala
+Test / fork := true,
+Test / javaOptions ++= Seq(
+  "--add-opens=java.base/java.nio=ALL-UNNAMED",
+  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+  "-Dio.netty.tryReflectionSetAccessible=true"
+)
+```
+
+**Client and server travel in pairs.** A `versions.json` is the single source of truth, read by `build.sbt` (Scala and Spark) and by `flake.nix` (what goes into the server's venv). If you bump Spark and forget pysail, nothing fails — it just starts answering odd things.
+
+---
+
+## 🧪 And with that, does Sail's corpus run?
+
+This is where the toy got interesting. Sail has its own conformance suite: Gherkin `.feature` files, pure SQL, compared against what real Spark returns. It is written for pytest-bdd. If the launcher works, that same corpus ought to run **from a JVM client** under Cucumber.
+
+It does. `spark/function/` is **4,972 scenarios** counted the way Cucumber runs them (one per `Examples` row; declared in the files they are 2,960), and they come out the other end as a report grouped **by cause**, not by scenario. That last part matters: one missing coercion fails hundreds of scenarios, and hundreds of issues for one bug helps nobody.
+
+What I learned there was not about Sail. It was about how easy it is to report bugs that do not exist.
+
+**Spark is the oracle, Sail is the subject.** The expected values were captured against real Spark, so a scenario failing *against Spark* is a bug in my harness and in nothing else. Running that baseline first should sit at ~99%. Whatever fails there is mine.
+
+**The corpus and the binary must come from the same release.** Running HEAD's corpus against pysail 0.7.0 produced **96 "divergences"**, including `sum` over strings — which had been fixed ten days after the release, 64 commits earlier. With the corpus pinned to `v0.7.0`, those 96 went to zero. Not hypothetical: it happened to me.
+
+**And then the harness bugs that looked like engine bugs.** Each one cost hours and each produced hundreds of false failures:
+
+| what was wrong | failures it caused |
+|---|---|
+| `query result` reads the table the *server* renders with `show()`, it does not `collect()` | 292 |
+| `config` has to be restored after each scenario | 113 |
+| Cucumber unescapes `\\` in `Examples` tables; pytest-bdd does not | 10 |
+| an empty Gherkin cell is an empty string, not NULL | (every empty-string one) |
+
+The `config` one is my favourite: **one** scenario that set `spark.sql.session.timeZone = America/New_York` and left it set shifted every later result by hours.
+
+Since the corpus only asserts a type where a scenario says `query schema` (901 of the 4,972), everything else compares rows as text — and there `decimal(29,2)` and `decimal(20,2)` render identically and pass. Dumping both engines' schemas and diffing them: **4,639 queries in common, 4,599 identical, 40 different**, in about six families. Those 40 are still unreviewed.
+
+---
+
+## 🛠️ The template: two engines, one `shared/`
+
+The other half of this is [`template-nix-sail-scala`](https://github.com/davidlghellin/template-nix-sail-scala), sibling to the [Python template](0003-template-nix-sail-en.md). Same premise: Nix pins the environment, CI runs the tests against **both engines**, and the example code is shaped like a real ETL.
+
+```bash
+nix develop   # JDK 21, sbt, scalafmt and the Sail server
+t             # tests against BOTH backends
+tc            # classic Spark only
+ts            # Sail only
+```
+
+The difference from the Python version: there the engine is chosen **at run time** with `SPARK_BACKEND`, here **at compile time**. And that is not a whim: `spark-sql` and `spark-connect-client-jvm` both ship the class `org.apache.spark.sql.SparkSession`, so they cannot share a classpath. Hence two subprojects.
+
+What is *not* duplicated is the code: `shared/` is compiled twice, once against each client. Spark 4 moved the common API into `spark-sql-api`, so the same transformations and **the same specs** serve both. Only where the session comes from changes:
+
+| | classic | connect |
+| --- | --- | --- |
+| Dependency | `spark-sql` | `spark-connect-client-jvm` |
+| Session | `.master("local[1]")` | `.remote(server.url)` |
+| Engine | JVM | Sail (Rust) |
+
+And one thing I wanted to check rather than assume, because the eventual goal is being able to drop classic Spark entirely. The whole Spark-side classpath of the `connect` subproject is:
+
+```
+spark-connect-client-jvm  spark-connect-shims  spark-common-utils
+spark-sketch  spark-unsafe  spark-variant  spark-tags
+```
+
+No `spark-sql`, no `spark-core`, no Hadoop, no Hive. The client jar carries the API inside it. `classic` is there as an oracle to compare against, not as something `connect` leans on.
+
+---
+
+## 🎯 The finding: it is not DataFrame against Dataset
+
+Here is the part I am writing this post for.
+
+The easy summary of all this would be *"DataFrames work on Sail, Datasets fail"*. It is false, and worse, it leads to exactly the wrong move. The axis that matters is **columns against closures**:
+
+| | runs on Sail | pushdown and pruning | typed |
+|---|---|---|---|
+| DataFrame + columns | yes | yes | no |
+| **Dataset + columns** | **yes** | **yes** | **yes** |
+| Dataset + closures | no | no | yes |
+
+The middle row gives up nothing to the first. It is the first row **plus the types, for free**. Encoders are derived on the **client**, so `as[T]`, `Seq[T].toDS()`, `Dataset[T]`, `Option[T]` and typed `collect()` cross Connect without breaking a sweat.
+
+What does not cross is a **closure**:
+
+| | on Sail | what it answers |
+|---|---|---|
+| `ds.map(lambda)` | ✗ | `wildcard with plan ID` |
+| `ds.filter(lambda)` | ✗ | `wildcard with plan ID` |
+| `ds.flatMap(lambda)` | ✗ | `wildcard with plan ID` |
+| `ds.groupByKey(lambda)` | ✗ | `Scala UDF is not supported yet` |
+| `ds.queryExecution` | ✗ | `UNSUPPORTED_CONNECT_FEATURE.DATASET_QUERY_EXECUTION` |
+
+The first four are one cause: Connect ships the lambda as **JVM bytecode**, and on the far side there is Rust. Nothing to deserialise it and nothing to run it. The fifth is something else: a Connect limitation any Connect server shares, not a gap in Sail.
+
+Notice that only `groupByKey` names the real reason. The other three die earlier, on a wildcard, and the accurate message Sail already has written is never reached: `resolve_map_partitions` resolves the UDF's arguments before it looks at what kind of UDF it is. That is a small, self-contained fix in Sail, and the message is pinned in a test that will go red the day it lands.
+
+The rule that predicts everything else: **anything expressible as a column travels; anything needing bytecode executed on the server does not.**
+
+---
+
+## 📉 And now the uncomfortable part
+
+The obvious reading of that table is that Sail is less capable: classic runs `ds.map(_.amount * 2)` and Sail does not.
+
+Measuring what classic actually *does* with it changes the reading. Reading a five-column parquet table:
+
+| closure, on classic | columns read | column form | columns read |
+|---|---|---|---|
+| `filter(_.amount > 50)` | 5 of 5 | `filter(col(...))` | 2 of 5 |
+| `map(_.amount)` | 5 of 5 | `select(col(...))` | 1 of 5 |
+| `groupByKey(_.country)` | 5 of 5 | `groupBy(col(...))` | 1 of 5 |
+| `flatMap(...)` | 5 of 5 | `explode(...)` | 1 of 5 |
+| `reduce(_ + _)` | 5 of 5 | `sum(col(...))` | 1 of 5 |
+
+Not one of those five closures mentions the `day` column. All five load it.
+
+And with a filter in play the pushdown goes too:
+
+| how it is written | filters pushed down | columns read |
+|---|---|---|
+| `filter(col("amount") > 50)` | `IsNotNull, GreaterThan(amount,50.00)` | 2 of 5 |
+| `filter(_.amount > 50)` (lambda) | **none** | **5 of 5** |
+
+A closure costs three things at once, and classic charges all three silently. No predicate reaches the file, so rows are read only to be discarded. No projection reaches it either, so every column is read to satisfy a lambda that touches one. And each row is deserialised into a JVM object so the closure has something to run against. On two rows this is invisible; on a billion it is the difference between reading 200 GB and reading 12.
+
+Look at the first row of that table: it is a `Dataset[Sale]`, fully typed, with pushdown and pruning intact. **It is not the Dataset that loses the optimisations — it is the closure.** Catalyst cannot see inside bytecode, so it cannot reason about it, move it, or push it anywhere.
+
+Sail, moreover, does the same optimisations and writes them into the plan:
+
+```
+DataSourceExec: file_groups={...},
+  projection=[branch, amount],
+  predicate=amount@3 > Some(5000),18,2,
+  pruning_predicate=amount_null_count@1 != row_count@2
+                    AND amount_max@0 > Some(5000),18,2
+```
+
+Column pruning, predicate pushdown, and row-group pruning from the parquet statistics. DataFusion writes the third one into the plan; Catalyst keeps it to itself.
+
+So:
+
+| | `filter(_.amount > 50)` |
+|---|---|
+| classic | runs — 5 columns of 5, no pushdown, every row deserialised, **silently** |
+| Sail | refuses |
+
+Seen from performance rather than from features, **the one treating you badly is classic**: it hands you the slow path without mentioning it, and you only find out by reading a plan, which almost nobody does. A loud failure gets fixed the same afternoon; a job reading 200 GB instead of 12 can live in production for years.
+
+It is also the argument against building the JVM UDF path into Sail. It would be months of work — a JNI bridge, a JVM lifecycle, a helper jar — to deliver an execution mode that is **slower than the alternative that already works**. The error message is worth fixing. The feature behind it, for anything a column can express, is worth refusing.
+
+Where the refusal does cost something real: a closure calling arbitrary Scala — a library, a lookup, logic no column can spell — has no column form to fall back on. That is a genuine limit, not a disguised favour.
+
+> How livable is the rule? **Not one of the six ETLs in the template contains a single Dataset closure.** Not the DataFrame one, not the five typed ones. The closures live only in the specs that exist to show what they cost.
+
+---
+
+## 🪄 Can the closure not just be translated?
+
+It is the obvious question by now. If `_.amount * 2` and `col("amount") * 2` mean the same thing, why do I have to rewrite one into the other by hand?
+
+The hard road is analysing **bytecode**, which is where this problem has always got stuck: by the time the closure is bytecode you have lost almost everything you needed to know about it. From a Scala macro you never have to go there. At compile time you have the **typed AST of the lambda** in front of you, which is an incomparably better starting point. That is what lives in `macros/`, and it works:
+
+```scala
+Expr.of[Sale](_.amount * 2)   // becomes  col("amount") * lit(2)
+```
+
+And wrapping the `Dataset` in a type of my own, the call site reads **exactly like the code that fails on Sail**:
+
+```scala
+val sales = TypedDataset(spark.table("sales").as[Sale])
+sales.filter(_.amount > 50).map(s => Doubled(s.country, s.amount * 2)).dataset
+```
+
+That compiles to a projection. The wrapper is needed because `Dataset.map` **cannot be intercepted**: a member always beats an implicit conversion, so an extension named `map` would compile, resolve to Spark's, and go on failing exactly as before. On a type of mine, `map` is a name like any other — the same rule that stops `Storage` calling its writer `write`.
+
+### The refusals are the interesting part
+
+A translator that is *nearly* right is worse than no translator. The failure mode that matters is not failing to compile: it is answering something **plausible and different**. So the macro refuses on **semantics**, not on syntax:
+
+| lambda | verdict | why |
+|---|---|---|
+| `_.userId % 2` | compiles | measured: `1` on both engines |
+| `_.userId / 2.0` | compiles | measured: `2.5` on both |
+| `_.userId / 2` | **does not compile** | Scala gives `2`; Spark gives `2.5`, typed Double |
+| `s.country + s.branch` | **does not compile** | `+` concatenates Strings in Scala, is arithmetic in Spark |
+| `s.product.toUpperCase` | **does not compile** | a method call: outside the subset |
+| `_.tariff == "X"` | compiles, but to `<=>` | `===` propagates NULL; Scala's `==` answers `false` |
+
+That last row is my favourite. Translating `==` to `===` was the obvious move and it was **wrong**, and it only shows up on a nullable column. The spec proves it with two rows, one with `tariff` NULL.
+
+All of it is asserted with `assertDoesNotCompile`, which is where the whole design rests: if the refusal arrived at run time it would be no better than what Sail already does.
+
+> The best argument for failing this way is a bug the macro itself had. An earlier version matched any call whose arity equalled the field count, so `s => swapped(s.a, s.b)` compiled as `Doubled(s.a, s.b)`: it ignored what `swapped` did and answered something else. Exactly the failure the spike exists to prevent, committed inside the spike. It now checks that the call is the constructor, and a `notAConstructor` lives in the tests whose only job is making sure that does not come back.
+
+And yes, it recovers what the closure was losing: `filterExpr` pushes the same predicate as the hand-written column — 2 columns of 5 — and `mapExpr` reads 1 of 5. The column form's numbers, in the lambda's shape.
+
+### And it still does not solve the problem
+
+Because using it means **changing the code**, which is the exact opposite of Sail's premise: swap the server, leave the job alone. A macro that demands rewriting the job does not save you rewriting the job.
+
+As an exercise it does answer something, and it is not nothing: the translation is **possible and cheap** for the subset people actually use, as long as you are willing to refuse everything else at compile time. The expensive part was never translating. It was deciding what not to translate.
+
+---
+
+## 🪤 Two Spark traps that have nothing to do with Sail
+
+Both turned up while building this, and neither is about engines. They are about Spark, and both are silent.
+
+### `as[T]` decodes by name; `insertInto` writes by position
+
+`as[T]` matches columns **by name**, but does not reorder the schema. A frame whose columns arrive as `(family, name, code)` becomes a `Dataset[Product]` whose schema is **still in that order**, while `collect()` hands back perfectly correct `Product` values. So every assertion you would think to write passes:
+
+```scala
+reversed.as[Product].collect().head          // Product(P1, Widget, TOOLS)  ✓
+reversed.as[Product].schema.fieldNames       // (family, name, code)        ✗
+```
+
+And then `insertInto` matches **by position** and writes the family into the code column. Nothing raises. Not even a warning.
+
+The `Conform` typeclass closes the hole. `Dataset.to(StructType)` is the engine — it reorders, drops extras and type-checks — and the typeclass adds the guard `to` lacks, **before** calling it:
+
+```scala
+wide.conformTo[Product]                    // reorders, drops what Product does not declare
+short.conformTo[Product]                   // ConformError: missing columns: family
+wide.conformTo[Product](Conform.exact)     // ConformError: unexpected columns: junk
+```
+
+The check running before rather than after is not cosmetic, and here Sail reappears: on a missing column **the two engines do not behave the same** (it is in the next section's table). Checking first is the only thing that makes them answer alike.
+
+### `withColumn` in a loop, and the README that had it wrong
+
+`withColumn` adds one column by wrapping the plan in one more `Project`, so in a loop it nests. So far, known folklore. What my own template's README claimed — and had wrong — is that the nesting reached the executed query. It does not:
+
+| plan | 5 chained `withColumn` | one `select` |
+|---|---|---|
+| analyzed | 6 `Project` | 2 |
+| optimized | 1 | 1 |
+| physical | 1 | 1 |
+
+Catalyst flattens it before execution. The cost is not a worse query: it is a **longer walk to the same query**, paid by the analyzer on every operation that follows. Long enough chains are a known way to blow its stack, with a trace that says nothing about the loop that caused it.
+
+I mention it because the correction came from measuring it, not from thinking harder. And because the number now lives in a spec rather than in anybody's memory.
+
+---
+
+## 🔬 Where the two engines really differ
+
+All measured against `pysail` 0.7.0 with the 4.2.0 JVM client, and every line pinned by a test that goes red if it stops being true:
+
+| | classic | Sail |
+|---|---|---|
+| invalid cast | `CAST_INVALID_INPUT` | `Cast error: Cannot cast string ...`, wrapped in `CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE` |
+| `to(schema)` missing a column | **invents it**, filled with NULL | **refuses**: `field not found in input schema` |
+| `DECIMAL(18,2) * 2` | `decimal(20,2)` | `decimal(29,2)` |
+| `DECIMAL(38,18) * 2` | `decimal(38,16)` | `decimal(38,18)` |
+| `DECIMAL(38,18) / 2` | `decimal(38,18)` | `decimal(38,22)` |
+| the plan | Catalyst: `Project`, `Filter` | DataFusion: `ProjectionExec`, `FilterExec` |
+
+The decimal rows have a sharper diagnosis than the table shows: the two agree whenever **both operands declare their precision**. `DECIMAL(18,2) * DECIMAL(1,0)` is `(20,2)` on both; `* DECIMAL(10,0)` is `(29,2)` on both. Only the **bare literal** parts them: Catalyst narrows the `2` to the smallest decimal that holds it, Sail keeps it at an `Int`'s width. The values come out equal either way; what moves is the schema, which is invisible until the result meets a table.
+
+And notice the `to(schema)` row, because it runs against expectation: **the strict one is Sail**. Classic invents the column and fills it with nulls.
+
+### Nothing is marked skipped
+
+The tempting move with these divergences is to mark the tests `ignore` or `pending` so the build goes green. The cost is that they go **quiet forever**: the day Sail closes the gap, nothing tells you, and the skip outlives its reason by years.
+
+So nothing here skips. Both arms stay live:
+
+```scala
+// Works on classic, expected to fail on Sail — asserted, not tolerated.
+failsOnSail()(sales.map(_.amount * 2).collect())
+```
+
+`failsOnSail` **asserts the failure**. If Sail ever runs the lambda, the test goes **red** and says the expectation is stale. Which is the point: a green build that has stopped checking anything is worse than a red one.
+
+---
+
+## 📮 Publishing to Maven Central in 2026
+
+A couple of things that cost me time and are not where they should be.
+
+**The Central Portal is not the plugin's default.** `sbt-sonatype` still points at `oss.sonatype.org`, the legacy OSSRH, which stopped taking new namespaces when it was sunset. Without this, `sbt ci-release` signs and stages perfectly into a host that will never publish it:
+
+```scala
+ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeCentralHost
+```
+
+**`sbt-ci-release` ends by calling `sonaRelease`**, a command no published version of `sbt-sonatype` defines. The build does everything right and dies on the last step with *"Not a valid command"*. You have to supply it:
+
+```scala
+addCommandAlias("sonaRelease", "sonatypeCentralUpload")
+```
+
+And `sonatypeCentralUpload` rather than `sonatypeCentralRelease` on purpose: it leaves the deployment at `VALIDATED`, so signatures, sources, javadoc and the POM can be inspected in the Portal before anything reaches Central. From there it is one click to publish, or *Drop* and it never existed. Maven Central is **immutable**: a version that goes out cannot be replaced or withdrawn.
+
+**The namespace does not have to match the repo.** `com.devel0pez` is verified with a DNS TXT record on the domain; the GitHub URL is only POM metadata. That is why the groupId is `com.devel0pez` while the repo lives at `devel0pez-com/sail-testkit`, with no problem. `io.github.*` would have tied them together.
+
+**`versionScheme` matters more than it looks.** `early-semver`, not `semver-spec`: under strict semver every `0.x` release is allowed to break anything, so a `0.1.0 → 0.1.1` bump would promise nothing. `early-semver` keeps the patch digit meaningful before 1.0.0.
+
+And releases go **by tag** — nothing publishes because a branch moved. `sbt-dynver` reads the version from the tag, so `v0.1.0` is `0.1.0`. `workflow_dispatch` keeps the one good thing the branch trigger had: running it by hand on an untagged commit produces a `-SNAPSHOT` and exercises credentials, signing and upload without leaving anything immutable on Central.
+
+---
+
+## ⚠️ What to know before pointing your suite at Sail
+
+- **Typed lambdas will not run.** `map`, `filter(_.x)`, `flatMap`, `groupByKey`, Scala UDFs. A suite written on typed lambdas will not run, and it is better to know before spending the afternoon.
+- **Neither will RDDs**, but that is not Sail: there is no RDD API over Connect at all.
+- **`queryExecution` is classic-only.** It is the first thing any plan-inspecting code reaches for.
+- **Do not `match` on error classes.** The two engines agree on the *semantics* (both refuse the cast) but not on the identity of the error.
+- **A case class declared inside the test class breaks encoders** by reflection. That failure is the test's fault, not Sail's. Declare them at file level.
+- **IntelliJ ignores `Test / javaOptions`.** Its ScalaTest runner does not pass the `--add-opens`, so the first `collect()` from the gutter dies with `InaccessibleObjectException`. Either tick *use sbt shell for builds and tests*, or copy the flags into the run configuration's VM options.
+
+---
+
+## 💭 Reflection
+
+Three things I take from this.
+
+**The real work was not in the engine, it was in the harness.** Of the hundreds of corpus failures, the ones that turned out to be real divergences were a handful. The rest were mine: a `collect()` where a `show()` belonged, a config left unrestored, backslashes Cucumber had eaten. Reporting an engine bug without ruling that out first is wasting somebody else's afternoon.
+
+**Sail is not less capable, it is more honest.** Every operation Sail refuses is exactly the one that was costing you a full scan on classic without saying so. I did not know that before measuring it, and it has changed how I write Spark in Scala regardless of which engine is underneath. The rule is simple: avoid closures — not because Sail cannot run them, but because they were never the fast path. Sail is just the first engine that says so out loud.
+
+**And one thing about publishing.** That the missing piece was this small — a `ProcessBuilder`, a free port, a thread draining a pipe and a ScalaTest trait — and that it still did not exist, says something about how far one ecosystem can sit from another. Sail has been serving Spark Connect perfectly well for a while; nobody had simply written the 200 lines of Scala the JVM needs to start it.
+
+I raised this in the LakeSail Slack before starting. Their answer was that a separate repo is fine, that a JVM launcher "would be interesting", that they cannot maintain a JVM component in-tree because of the extra CI it implies, but that examples would help. So the next thing is a docs PR to `lakehq/sail` — *"Using Sail from the JVM"* — with the server startup, the Arrow flags, the `pyspark` requirement and the typed API table.
+
+Status: **0.1.0**. Early. It does one thing and the tests cover it, but it has not been through much beyond that. Issues and PRs welcome. And if a JVM kit ever lands upstream, this one should give way to it.
+
+- 📦 [`com.devel0pez:sail-testkit_2.13`](https://central.sonatype.com/artifact/com.devel0pez/sail-testkit_2.13) on Maven Central
+- 🐙 [devel0pez-com/sail-testkit](https://github.com/devel0pez-com/sail-testkit)
+- ⛵ [davidlghellin/template-nix-sail-scala](https://github.com/davidlghellin/template-nix-sail-scala)
+
+---
+
+## 📚 Previous posts
+
+[Sail + PySpark](0001-sail.md) | [Nix + Sail](0002-nix-sail.md) | [Nix template](0003-template-nix-sail-en.md) | [Maintainer at nixpkgs](0004-sail-nixpkgs-maintainer-en.md) | [NixOS on my rpi3s](0005-nixos-rpi3-en.md)

--- a/0006-sail-jvm.md
+++ b/0006-sail-jvm.md
@@ -1,0 +1,436 @@
+---
+layout: default
+title: "Sail desde la JVM: un test kit en Maven Central y lo que encontré por el camino"
+date: 2026-08-30
+categories: Blog
+---
+
+# ⛵ Sail desde la JVM: un test kit en Maven Central y lo que encontré por el camino
+
+Llevo unos cuantos posts hablando de [Sail](https://github.com/lakehq/sail) desde Python. La pregunta que faltaba era la evidente: **¿puedo coger mis tests de Spark en Scala y apuntarlos a Sail?**
+
+La respuesta corta es que sí, y que corre muchísimo más de lo que esperaba. La respuesta larga es este post: un launcher publicado en Maven Central, un template con dos motores, y un hallazgo que me ha cambiado cómo escribo Spark — y que no va de Sail, va de Spark.
+
+---
+
+## 🕳️ El hueco
+
+Sail habla **Spark Connect**. Y Spark publica un cliente JVM, `spark-connect-client-jvm`, que habla ese mismo protocolo. Así que sobre el papel la pieza está: cliente Scala, servidor Rust, gRPC en medio.
+
+El problema es arrancarlo. Sail es un binario de Rust **distribuido como wheel de Python**. Desde Python haces `pip install pysail` y `sail spark server`, y ya. Desde la JVM no hay absolutamente nada que levante un servidor: no hay artefacto en Maven, no hay clase que llamar, no hay nada.
+
+Eso es lo que hace [`sail-testkit`](https://github.com/devel0pez-com/sail-testkit). Es la pieza que faltaba, y no es más que eso: arranca el proceso, te da la URL, y lo mata cuando termina la suite.
+
+Y ya **está en Maven Central**:
+
+```scala
+libraryDependencies += "com.devel0pez" %% "sail-testkit" % "0.1.0" % Test
+```
+
+---
+
+## 📦 Cómo se usa
+
+Mezclas `SailSuite` en una suite de ScalaTest y tienes un `spark` que habla con Sail:
+
+```scala
+import com.devel0pez.sail.testkit.SailSuite
+import org.scalatest.funsuite.AnyFunSuite
+
+class MyEtlSpec extends AnyFunSuite with SailSuite {
+  test("agrega por clave") {
+    val out = MyEtl.transform(spark.read.parquet("src/test/resources/input"))
+    assert(out.count() == 3)
+  }
+}
+```
+
+`sbt test` y ya. Un servidor por suite, arrancado en `beforeAll` y parado en `afterAll`. Si prefieres manejar tú la sesión, el launcher está suelto:
+
+```scala
+SailServer.withServer { server =>
+  val spark = SparkSession.builder().remote(server.url).getOrCreate()
+  ...
+}
+```
+
+Hay una decisión de diseño de la que estoy contento: **`SailSuite` no configura nada de la sesión**. Ni modo ANSI, ni zona horaria, ni nada que cambie lo que una query significa. Eso son decisiones de tu proyecto, y un test kit que las tomara por su cuenta estaría respondiendo a una pregunta que nadie le ha hecho. Hay un hook y punto:
+
+```scala
+override protected def configureSession(session: SparkSession): Unit =
+  session.conf.set("spark.sql.ansi.enabled", "true")
+```
+
+Ese hook, por cierto, no salió de pensarlo bien: salió de consumir el artefacto desde el template Scala vía `publishLocal` y darme cuenta de que estaba peleándome con mi propia librería.
+
+### Los detalles que cuestan una tarde
+
+Tres cosas del launcher que parecen tontería y no lo son:
+
+**El pipe hay que drenarlo.** Sail escribe a stderr. Si nadie lee ese pipe, se llena y Sail se bloquea en su propio logging. El síntoma es un cuelgue sin causa visible en ningún sitio. Descartar la salida también lo evitaría, pero entonces un servidor que se muere se lleva el motivo con él.
+
+**Así que se guardan las últimas 20 líneas** y se meten en el mensaje de error. Un servidor que revienta al arrancar dice por qué:
+
+```
+The Sail server exited while starting up (code 1). It printed:
+  error: failed to bind: Address already in use (os error 48)
+```
+
+**El hilo lector es daemon.** Un test kit no puede ser nunca el motivo por el que una JVM se niega a salir.
+
+---
+
+## 🧨 Los requisitos que no están escritos en ningún sitio
+
+Esta es la sección que me habría ahorrado la mitad del trabajo.
+
+**`pyspark` tiene que estar instalado al lado de `pysail`.** Sail resuelve *su* versión de Spark preguntándole a ese módulo, en su propio lado. Sin él, `spark.version` te contesta:
+
+```
+invalid argument: failed to get PySpark version:
+ModuleNotFoundError: No module named 'pyspark'
+```
+
+**Java 17+ y los `--add-opens`.** Spark y Arrow entran en internals de la JDK por reflexión, y eso está cerrado desde Java 17. `spark-submit` pasa esos flags por ti; sbt no. Sin ellos, el primer `collect()` muere con `sun.misc.Unsafe ... not available` — y es un fallo de *runtime*, así que un build que compila limpio se muere igual en la primera fila.
+
+```scala
+Test / fork := true,
+Test / javaOptions ++= Seq(
+  "--add-opens=java.base/java.nio=ALL-UNNAMED",
+  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+  "-Dio.netty.tryReflectionSetAccessible=true"
+)
+```
+
+**Cliente y servidor viajan en pareja.** Un `versions.json` es la única fuente de verdad, y lo leen `build.sbt` (Scala y Spark) y `flake.nix` (qué se instala en el venv del servidor). Si subes Spark y te olvidas de pysail, no falla: empieza a contestar cosas raras.
+
+---
+
+## 🧪 Y con esto, ¿corre el corpus de Sail?
+
+Aquí es donde el juguete se volvió interesante. Sail tiene su propia suite de conformidad: ficheros `.feature` de Gherkin, SQL puro, comparados contra lo que Spark de verdad devuelve. Está escrita para pytest-bdd. Si el launcher funciona, ese mismo corpus tendría que correr **desde un cliente JVM** con Cucumber.
+
+Corre. `spark/function/` son **4.972 escenarios** contados como los ejecuta Cucumber (uno por fila de `Examples`; declarados en los ficheros son 2.960), y salen por la puerta con un informe agrupado **por causa**, no por escenario. Eso último importa: una coerción que falta tumba cientos de escenarios, y cientos de issues para un solo bug no ayuda a nadie.
+
+Lo que aprendí ahí no fue sobre Sail. Fue sobre lo fácil que es reportar bugs que no existen.
+
+**Spark es el oráculo, Sail es el sujeto.** Los valores esperados se capturaron contra Spark real, así que un escenario que falla *contra Spark* es un bug de mi harness y de nada más. Correr esa línea base primero debería dar ~99%. Lo que falle ahí es mío.
+
+**El corpus y el binario tienen que venir de la misma release.** Correr el corpus de HEAD contra pysail 0.7.0 produjo **96 "divergencias"**, incluida `sum` sobre strings — que se había arreglado diez días después de la release, 64 commits antes. Con el corpus fijado a `v0.7.0`, esas 96 se fueron a cero. No es hipotético: me pasó.
+
+**Y luego los bugs del harness que parecían bugs del motor.** Cada uno costó horas y cada uno produjo cientos de fallos falsos:
+
+| lo que estaba mal | fallos que provocó |
+|---|---|
+| `query result` lee la tabla que el servidor renderiza con `show()`, no hace `collect()` | 292 |
+| `config` hay que restaurarlo al acabar cada escenario | 113 |
+| Cucumber desescapa `\\` en tablas de `Examples`; pytest-bdd no | 10 |
+| una celda vacía de Gherkin es string vacío, no NULL | (todas las de string vacío) |
+
+El de `config` es el más bonito de todos: **un** escenario que ponía `spark.sql.session.timeZone = America/New_York` y no lo devolvía desplazaba las horas de todos los resultados posteriores.
+
+Como el corpus solo afirma un tipo donde el escenario dice `query schema` (901 de los 4.972), el resto compara filas como texto — y ahí `decimal(29,2)` y `decimal(20,2)` se renderizan igual y pasan. Volcando los schemas de ambos motores y diffeando: **4.639 queries en común, 4.599 idénticas, 40 distintas**, en unas seis familias. Esas 40 siguen sin revisar.
+
+---
+
+## 🛠️ El template: dos motores, un solo `shared/`
+
+La otra mitad de esto es [`template-nix-sail-scala`](https://github.com/davidlghellin/template-nix-sail-scala), hermano del [template de Python](0003-template-nix-sail.md). Misma premisa: Nix fija el entorno, CI corre los tests contra **los dos motores**, y el código de ejemplo tiene forma de ETL de verdad.
+
+```bash
+nix develop   # JDK 21, sbt, scalafmt y el servidor Sail
+t             # tests contra AMBOS backends
+tc            # solo Spark clásico
+ts            # solo Sail
+```
+
+La diferencia con la versión Python: allí el motor se elige **en tiempo de ejecución** con `SPARK_BACKEND`, aquí **en tiempo de compilación**. Y no es un capricho: `spark-sql` y `spark-connect-client-jvm` traen los dos la clase `org.apache.spark.sql.SparkSession`, así que no pueden compartir classpath. De ahí dos subproyectos.
+
+Lo que *no* está duplicado es el código: `shared/` se compila dos veces, una contra cada cliente. Spark 4 movió la API común a `spark-sql-api`, así que las mismas transformaciones y **los mismos specs** sirven para los dos. Solo cambia de dónde sale la sesión:
+
+| | classic | connect |
+| --- | --- | --- |
+| Dependencia | `spark-sql` | `spark-connect-client-jvm` |
+| Sesión | `.master("local[1]")` | `.remote(server.url)` |
+| Motor | JVM | Sail (Rust) |
+
+Y una cosa que quise comprobar en vez de asumir, porque el objetivo último es poder tirar Spark clásico del todo. El classpath entero del lado Spark en el subproyecto `connect` es:
+
+```
+spark-connect-client-jvm  spark-connect-shims  spark-common-utils
+spark-sketch  spark-unsafe  spark-variant  spark-tags
+```
+
+Ni `spark-sql`, ni `spark-core`, ni Hadoop, ni Hive. El jar del cliente lleva la API dentro. `classic` está ahí como oráculo contra el que comparar, no como algo de lo que `connect` dependa.
+
+---
+
+## 🎯 El hallazgo: no es DataFrame contra Dataset
+
+Aquí está la parte por la que escribo el post.
+
+El resumen fácil de todo esto sería *"los DataFrames funcionan en Sail, los Datasets fallan"*. Es falso, y además lleva justo al movimiento equivocado. El eje que importa es **columnas contra closures**:
+
+| | corre en Sail | pushdown y pruning | tipado |
+|---|---|---|---|
+| DataFrame + columnas | sí | sí | no |
+| **Dataset + columnas** | **sí** | **sí** | **sí** |
+| Dataset + closures | no | no | sí |
+
+La fila del medio no cede nada respecto a la primera. Es la primera **más los tipos, gratis**. Los encoders se derivan en el **cliente**, así que `as[T]`, `Seq[T].toDS()`, `Dataset[T]`, `Option[T]` y el `collect()` tipado cruzan Connect sin despeinarse.
+
+Lo que no cruza es un **closure**:
+
+| | en Sail | qué contesta |
+|---|---|---|
+| `ds.map(lambda)` | ✗ | `wildcard with plan ID` |
+| `ds.filter(lambda)` | ✗ | `wildcard with plan ID` |
+| `ds.flatMap(lambda)` | ✗ | `wildcard with plan ID` |
+| `ds.groupByKey(lambda)` | ✗ | `Scala UDF is not supported yet` |
+| `ds.queryExecution` | ✗ | `UNSUPPORTED_CONNECT_FEATURE.DATASET_QUERY_EXECUTION` |
+
+Los cuatro primeros son la misma causa: Connect manda el lambda como **bytecode de la JVM**, y al otro lado hay Rust. No hay nada que lo deserialice ni nada que lo ejecute. El quinto es otra cosa: una limitación de Connect que comparte cualquier servidor Connect, no un hueco de Sail.
+
+Fíjate en que solo `groupByKey` dice el motivo de verdad. Los otros tres mueren antes, en un wildcard, y el mensaje bueno que Sail ya tiene escrito no llega a leerse: `resolve_map_partitions` resuelve los argumentos de la UDF antes de mirar qué tipo de UDF es. Es un arreglo pequeño y autocontenido en Sail, y el mensaje está fijado en un test que se pondrá rojo el día que lo arreglen.
+
+La regla que predice todo lo demás: **lo que se puede expresar como columna viaja; lo que necesita bytecode ejecutándose en el servidor, no.**
+
+---
+
+## 📉 Y ahora la parte incómoda
+
+La lectura obvia de esa tabla es que Sail es menos capaz: clásico corre `ds.map(_.amount * 2)` y Sail no.
+
+Medir qué hace clásico *de verdad* con eso cambia la lectura. Leyendo una tabla parquet de cinco columnas:
+
+| closure, en clásico | columnas leídas | forma de columna | columnas leídas |
+|---|---|---|---|
+| `filter(_.amount > 50)` | 5 de 5 | `filter(col(...))` | 2 de 5 |
+| `map(_.amount)` | 5 de 5 | `select(col(...))` | 1 de 5 |
+| `groupByKey(_.country)` | 5 de 5 | `groupBy(col(...))` | 1 de 5 |
+| `flatMap(...)` | 5 de 5 | `explode(...)` | 1 de 5 |
+| `reduce(_ + _)` | 5 de 5 | `sum(col(...))` | 1 de 5 |
+
+Ninguno de esos cinco closures menciona la columna `day`. Los cinco la cargan.
+
+Y con un filtro en juego se va también el pushdown:
+
+| cómo está escrito | filtros empujados | columnas leídas |
+|---|---|---|
+| `filter(col("amount") > 50)` | `IsNotNull, GreaterThan(amount,50.00)` | 2 de 5 |
+| `filter(_.amount > 50)` (lambda) | **ninguno** | **5 de 5** |
+
+Un closure cuesta tres cosas a la vez, y clásico te las cobra las tres en silencio. No llega ningún predicado al fichero, así que se leen filas solo para tirarlas. No llega ninguna proyección, así que se leen todas las columnas para satisfacer un lambda que toca una. Y cada fila se deserializa a un objeto JVM para que el closure tenga contra qué correr. Con dos filas esto es invisible; con mil millones es la diferencia entre leer 200 GB y leer 12.
+
+Ojo a la primera fila de esa tabla: es un `Dataset[Sale]`, completamente tipado, con pushdown y pruning intactos. **No es el Dataset el que pierde las optimizaciones — es el closure.** Catalyst no puede ver dentro del bytecode, así que no puede razonar sobre él, ni moverlo, ni empujarlo a ningún sitio.
+
+Sail, además, hace las mismas optimizaciones y las escribe en el plan:
+
+```
+DataSourceExec: file_groups={...},
+  projection=[branch, amount],
+  predicate=amount@3 > Some(5000),18,2,
+  pruning_predicate=amount_null_count@1 != row_count@2
+                    AND amount_max@0 > Some(5000),18,2
+```
+
+Pruning de columnas, pushdown de predicado, y pruning de row-groups por las estadísticas del parquet. DataFusion escribe la tercera en el plan; Catalyst se la guarda.
+
+Así que:
+
+| | `filter(_.amount > 50)` |
+|---|---|
+| clásico | corre — 5 columnas de 5, sin pushdown, cada fila deserializada, **en silencio** |
+| Sail | se niega |
+
+Visto desde el rendimiento en vez de desde las features, **el que te trata mal es clásico**: te da el camino lento sin mencionarlo, y solo te enteras leyendo un plan, cosa que casi nadie hace. Un fallo ruidoso se arregla esa misma tarde; un job que lee 200 GB en vez de 12 puede vivir años en producción.
+
+Y es también el argumento en contra de construir el camino de UDFs JVM dentro de Sail. Serían meses de trabajo — un puente JNI, un ciclo de vida de JVM, un jar auxiliar — para entregar un modo de ejecución **más lento que la alternativa que ya funciona**. El mensaje de error merece arreglarse. La feature que hay detrás, para todo lo que una columna sepa expresar, merece rechazarse.
+
+Donde el rechazo sí cuesta algo real: un closure que llama a Scala arbitrario — una librería, un lookup, lógica que ninguna columna deletrea — no tiene forma de columna a la que caer. Ese es un límite de verdad, no un favor disfrazado.
+
+> ¿Cómo de vivible es la regla? **Ninguno de los seis ETLs del template contiene un solo closure de Dataset.** Ni el de DataFrames ni los cinco tipados. Los closures solo viven en los specs que existen para enseñar lo que cuestan.
+
+---
+
+## 🪄 ¿Y no se puede traducir el closure solo?
+
+Es la pregunta obvia a estas alturas. Si `_.amount * 2` y `col("amount") * 2` significan lo mismo, ¿por qué tengo que reescribir una en la otra a mano?
+
+La vía difícil es analizar **bytecode**, que es donde este problema lleva atascado desde siempre: para cuando el closure es bytecode, ya has perdido casi todo lo que necesitabas saber de él. Desde un macro de Scala no hace falta llegar ahí. En tiempo de compilación tienes delante el **AST tipado del lambda**, que es un punto de partida incomparablemente mejor. Eso es lo que hay en `macros/`, y funciona:
+
+```scala
+Expr.of[Sale](_.amount * 2)   // se convierte en  col("amount") * lit(2)
+```
+
+Y envolviendo el `Dataset` en un tipo propio, el call site queda **idéntico al código que falla en Sail**:
+
+```scala
+val sales = TypedDataset(spark.table("sales").as[Sale])
+sales.filter(_.amount > 50).map(s => Doubled(s.country, s.amount * 2)).dataset
+```
+
+Eso compila a una proyección. Hace falta el wrapper porque `Dataset.map` **no se puede interceptar**: un miembro siempre gana a una conversión implícita, así que una extensión llamada `map` compilaría, resolvería a la de Spark y seguiría fallando igual. Sobre un tipo mío, `map` es un nombre como cualquier otro — la misma regla por la que `Storage` no puede llamar `write` a su escritor.
+
+### Lo interesante son los rechazos
+
+Un traductor *casi* correcto es peor que ningún traductor. El modo de fallo que importa no es que no compile: es que conteste algo **plausible y distinto**. Así que el macro no rechaza por sintaxis, rechaza por **semántica**:
+
+| lambda | veredicto | por qué |
+|---|---|---|
+| `_.userId % 2` | compila | medido: `1` en los dos motores |
+| `_.userId / 2.0` | compila | medido: `2.5` en los dos |
+| `_.userId / 2` | **no compila** | Scala da `2`; Spark da `2.5`, y de tipo Double |
+| `s.country + s.branch` | **no compila** | `+` concatena Strings en Scala, es aritmética en Spark |
+| `s.product.toUpperCase` | **no compila** | llamada a método: fuera del subconjunto |
+| `_.tariff == "X"` | compila, pero a `<=>` | `===` propaga NULL; el `==` de Scala contesta `false` |
+
+La última fila es mi favorita. Traducir `==` a `===` era lo evidente y era **incorrecto**, y solo se nota sobre una columna nullable. El spec lo prueba con dos filas, una con `tariff` a NULL.
+
+Todo eso se afirma con `assertDoesNotCompile`, que es donde descansa el diseño entero: si el rechazo llegara en tiempo de ejecución no sería mejor que lo que Sail ya hace.
+
+> El mejor argumento a favor de fallar así es un bug que tuvo el propio macro. Una versión anterior casaba cualquier llamada cuya aridad coincidiera con el número de campos, así que `s => swapped(s.a, s.b)` compilaba como `Doubled(s.a, s.b)`: ignoraba lo que `swapped` hacía y contestaba otra cosa. Exactamente el fallo que el spike existe para prevenir, cometido dentro del spike. Ahora comprueba que la llamada sea el constructor, y en los tests vive un `notAConstructor` cuyo único trabajo es que eso no vuelva.
+
+Y sí, recupera lo que el closure perdía: `filterExpr` empuja el mismo predicado que la columna escrita a mano — 2 columnas de 5 — y `mapExpr` lee 1 de 5. Las cifras de la forma de columna, con la forma del lambda.
+
+### Y aun así no resuelve el problema
+
+Porque para usarlo **hay que tocar el código**, que es justo lo contrario de la premisa de Sail: cambias el servidor y dejas el job en paz. Un macro que exige reescribir el job no te ahorra reescribir el job.
+
+Como ejercicio sí contesta algo, y no es poco: la traducción es **posible y barata** para el subconjunto que de verdad se usa, siempre que estés dispuesto a rechazar todo lo demás en tiempo de compilación. La parte cara nunca fue traducir. Fue decidir qué no traducir.
+
+---
+
+## 🪤 Dos trampas de Spark que no tienen nada que ver con Sail
+
+Salieron montando todo esto y no van de motores. Van de Spark, y las dos son silenciosas.
+
+### `as[T]` decodifica por nombre; `insertInto` escribe por posición
+
+`as[T]` casa las columnas **por nombre**, pero no reordena el schema. Un frame cuyas columnas vienen como `(family, name, code)` se convierte en un `Dataset[Product]` cuyo schema **sigue en ese orden**, mientras `collect()` te devuelve valores `Product` perfectamente correctos. Así que todas las aserciones que se te ocurriría escribir pasan:
+
+```scala
+reversed.as[Product].collect().head          // Product(P1, Widget, TOOLS)  ✓
+reversed.as[Product].schema.fieldNames       // (family, name, code)        ✗
+```
+
+Y después `insertInto` casa **por posición** y te escribe la familia en la columna del código. No salta nada. Ni un warning.
+
+El typeclass `Conform` cierra el agujero. `Dataset.to(StructType)` es el motor —reordena, descarta lo que sobra y comprueba tipos— y el typeclass añade la guarda que a `to` le falta, **antes** de llamarlo:
+
+```scala
+wide.conformTo[Product]                    // reordena, descarta lo que Product no declara
+short.conformTo[Product]                   // ConformError: missing columns: family
+wide.conformTo[Product](Conform.exact)     // ConformError: unexpected columns: junk
+```
+
+Que la comprobación vaya antes y no después no es cosmético, y aquí sí reaparece Sail: ante una columna que falta **los dos motores no se comportan igual** (está en la tabla de la sección siguiente). Comprobar antes es lo único que hace que contesten lo mismo.
+
+### `withColumn` en bucle, y el README que lo contaba mal
+
+`withColumn` añade una columna envolviendo el plan en un `Project` más, así que llamado en bucle anida. Hasta ahí, folklore conocido. Lo que el README de mi propio template afirmaba —y estaba mal— es que ese anidamiento llegaba a la query ejecutada. No llega:
+
+| plan | 5 `withColumn` encadenados | un solo `select` |
+|---|---|---|
+| analizado | 6 `Project` | 2 |
+| optimizado | 1 | 1 |
+| físico | 1 | 1 |
+
+Catalyst lo aplana antes de ejecutar. El coste no es una query peor: es un **camino más largo hasta la misma query**, que paga el analizador en cada operación posterior. Con cadenas suficientemente largas es una forma conocida de reventar su pila, con una traza que no menciona el bucle que la causó.
+
+Lo cuento porque la corrección salió de medirlo, no de pensarlo mejor. Y porque el número vive ahora en un spec en vez de en la memoria de nadie.
+
+---
+
+## 🔬 Dónde discrepan de verdad los dos motores
+
+Todo medido contra `pysail` 0.7.0 con el cliente JVM 4.2.0, y cada línea fijada por un test que se pone rojo si deja de ser cierta:
+
+| | clásico | Sail |
+|---|---|---|
+| cast inválido | `CAST_INVALID_INPUT` | `Cast error: Cannot cast string ...`, envuelto en `CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE` |
+| `to(schema)` sin una columna | **se la inventa**, a NULL | **se niega**: `field not found in input schema` |
+| `DECIMAL(18,2) * 2` | `decimal(20,2)` | `decimal(29,2)` |
+| `DECIMAL(38,18) * 2` | `decimal(38,16)` | `decimal(38,18)` |
+| `DECIMAL(38,18) / 2` | `decimal(38,18)` | `decimal(38,22)` |
+| el plan | Catalyst: `Project`, `Filter` | DataFusion: `ProjectionExec`, `FilterExec` |
+
+Lo de los decimales tiene un diagnóstico más fino que el que enseña la tabla: los dos coinciden siempre que **ambos operandos declaran su precisión**. `DECIMAL(18,2) * DECIMAL(1,0)` es `(20,2)` en los dos; `* DECIMAL(10,0)` es `(29,2)` en los dos. Solo los separa el **literal pelado**: Catalyst estrecha el `2` al decimal más pequeño que lo contiene, Sail lo mantiene al ancho de un `Int`. Los valores salen iguales de todas formas; lo que se mueve es el schema, que es invisible hasta que el resultado se encuentra con una tabla.
+
+Y fíjate en la fila de `to(schema)`, porque va al revés de lo que uno esperaría: **el estricto es Sail**. Clásico se inventa la columna y la rellena de nulls.
+
+### Nada se marca como skipped
+
+La tentación con estas divergencias es marcar los tests como `ignore` o `pending` para que el build salga verde. El coste es que se quedan **callados para siempre**: el día que Sail cierre el hueco, nada te lo dice, y el skip sobrevive a su motivo durante años.
+
+Así que aquí no se salta nada. Los dos brazos siguen vivos:
+
+```scala
+// Corre en clásico, se espera que falle en Sail — afirmado, no tolerado.
+failsOnSail()(sales.map(_.amount * 2).collect())
+```
+
+`failsOnSail` **afirma el fallo**. Si Sail algún día corre el lambda, el test se pone **rojo** y dice que la expectativa está caducada. Que es exactamente el punto: un build verde que ha dejado de comprobar nada es peor que uno rojo.
+
+---
+
+## 📮 Publicar en Maven Central en 2026
+
+Un par de cosas que me costaron y que no están donde deberían.
+
+**El Central Portal no es el default del plugin.** `sbt-sonatype` sigue apuntando a `oss.sonatype.org`, el OSSRH legacy, que dejó de admitir namespaces nuevos cuando lo jubilaron. Sin esto, `sbt ci-release` firma y sube correctamente a un host que nunca va a publicar nada:
+
+```scala
+ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeCentralHost
+```
+
+**`sbt-ci-release` termina llamando a `sonaRelease`**, un comando que ninguna versión publicada de `sbt-sonatype` define. El build hace todo bien y se muere en el último paso con *"Not a valid command"*. Hay que dárselo:
+
+```scala
+addCommandAlias("sonaRelease", "sonatypeCentralUpload")
+```
+
+Y ahí `sonatypeCentralUpload` en vez de `sonatypeCentralRelease` a propósito: deja el deployment en `VALIDATED`, de modo que firmas, sources, javadoc y POM se pueden mirar en el Portal antes de que nada llegue a Central. De ahí es un clic publicar, o *Drop* y nunca existió. Maven Central es **inmutable**: una versión que sale no se puede reemplazar ni retirar.
+
+**El namespace no tiene que coincidir con el repo.** `com.devel0pez` se verifica con un registro DNS TXT en el dominio; la URL de GitHub es solo metadata del POM. Por eso el groupId es `com.devel0pez` y el repo vive en `devel0pez-com/sail-testkit`, sin problema. Con `io.github.*` habrían quedado atados.
+
+**`versionScheme` importa más de lo que parece.** `early-semver`, no `semver-spec`: bajo semver estricto toda release `0.x` puede romper lo que quiera, así que un salto `0.1.0 → 0.1.1` no prometería nada. `early-semver` mantiene el dígito de patch con significado antes del 1.0.0.
+
+Y las releases van **por tag**, nada publica porque una rama se mueva. `sbt-dynver` lee la versión del tag, así que `v0.1.0` es `0.1.0`. El `workflow_dispatch` se queda para lo único bueno que tenía el trigger por rama: lanzarlo a mano sobre un commit sin tag produce un `-SNAPSHOT` y prueba credenciales, firma y subida sin dejar nada inmutable en Central.
+
+---
+
+## ⚠️ Lo que conviene saber antes de apuntar tu suite a Sail
+
+- **Los lambdas tipados no van.** `map`, `filter(_.x)`, `flatMap`, `groupByKey`, UDFs de Scala. Una suite escrita a base de lambdas tipados no va a correr, y mejor saberlo antes de gastar la tarde.
+- **RDDs tampoco**, pero eso no es de Sail: no hay API de RDD sobre Connect, punto.
+- **`queryExecution` es solo de clásico.** Es lo primero a lo que echa mano cualquier código que inspeccione planes.
+- **No hagas `match` sobre error classes.** Los dos motores coinciden en la *semántica* (los dos rechazan el cast) pero no en la identidad del error.
+- **Una case class declarada dentro de la clase de test rompe los encoders** por reflexión. Ese fallo es del test, no de Sail. Decláralas a nivel de fichero.
+- **IntelliJ ignora `Test / javaOptions`.** Su runner de ScalaTest no pasa los `--add-opens`, así que el primer `collect()` desde el gutter muere con `InaccessibleObjectException`. O marcas *use sbt shell for builds and tests*, o copias los flags a las VM options de la run configuration.
+
+---
+
+## 💭 Reflexión
+
+Tres cosas me llevo de esto.
+
+**El trabajo de verdad no estuvo en el motor, estuvo en el harness.** De los cientos de fallos del corpus, los que resultaron ser divergencias reales eran un puñado. Los demás eran míos: un `collect()` donde tocaba un `show()`, una config sin restaurar, unos backslashes que Cucumber se comía. Reportar un bug de motor sin haber descartado eso primero es hacerle perder la tarde a otro.
+
+**Sail no es menos capaz, es más honesto.** Cada operación que Sail rechaza es exactamente la que en clásico te estaba costando un scan completo sin avisar. Eso no lo sabía antes de medirlo, y ha cambiado cómo escribo Spark en Scala independientemente de qué motor haya debajo. La regla es simple: evita los closures — no porque Sail no pueda con ellos, sino porque nunca fueron el camino rápido. Sail es solo el primer motor que lo dice en voz alta.
+
+**Y una cosa sobre publicar.** Que la pieza que faltaba fuera tan pequeña — un `ProcessBuilder`, un puerto libre, un hilo drenando un pipe y un trait de ScalaTest — y que aun así no existiera, dice algo sobre lo lejos que puede estar un ecosistema de otro. Sail lleva tiempo corriendo Spark Connect perfectamente; simplemente nadie había escrito las 200 líneas de Scala que hacen falta para que la JVM lo arranque.
+
+Esto lo hablé en el Slack de LakeSail antes de empezar. Su respuesta fue que un repo aparte está bien, que un launcher JVM "sería interesante", que no pueden mantener un componente JVM in-tree por el CI extra que implica, pero que ejemplos ayudarían. Así que lo siguiente es un PR de documentación a `lakehq/sail` — *"Using Sail from the JVM"* — con el arranque del servidor, los flags de Arrow, el requisito de `pyspark` y la tabla de la API tipada.
+
+Estado: **0.1.0**. Temprano. Hace una cosa y los tests la cubren, pero no ha pasado por mucho más que eso. Issues y PRs bienvenidos. Y si algún día aparece un kit JVM upstream, este debería apartarse.
+
+- 📦 [`com.devel0pez:sail-testkit_2.13`](https://central.sonatype.com/artifact/com.devel0pez/sail-testkit_2.13) en Maven Central
+- 🐙 [devel0pez-com/sail-testkit](https://github.com/devel0pez-com/sail-testkit)
+- ⛵ [davidlghellin/template-nix-sail-scala](https://github.com/davidlghellin/template-nix-sail-scala)
+
+---
+
+## 📚 Posts anteriores
+
+[Sail + PySpark](0001-sail.md) | [Nix + Sail](0002-nix-sail.md) | [Template Nix](0003-template-nix-sail.md) | [Maintainer en nixpkgs](0004-sail-nixpkgs-maintainer.md) | [NixOS en mis rpi3](0005-nixos-rpi3.md)

--- a/index.md
+++ b/index.md
@@ -8,6 +8,7 @@ css: /assets/css/style.css
 
 Explora temas como **Rust**, **Big Data**.
 
+- Séptimo post [Sail desde la JVM](0006-sail-jvm.md) · [English](0006-sail-jvm-en.md)
 - Sexto post [NixOS en mis rpi3](0005-nixos-rpi3.md) · [English](0005-nixos-rpi3-en.md)
 - Quinto post [maintainer sail en nixpkgs](0004-sail-nixpkgs-maintainer.md) · [English](0004-sail-nixpkgs-maintainer-en.md)
 - Cuarto post [template nix-sail](0003-template-nix-sail.md) · [English](0003-template-nix-sail-en.md)


### PR DESCRIPTION
sail-testkit is on Maven Central as com.devel0pez:sail-testkit 0.1.0, so the post it came out of goes up with it: the JVM launcher, Sail's feature corpus driven from Cucumber, the Scala template with both backends, and the finding the two repos actually produced — the axis is columns against closures, not DataFrame against Dataset.